### PR TITLE
Replace pycrypto with pycryptodome

### DIFF
--- a/custom_components/philips-airpurifier/manifest.json
+++ b/custom_components/philips-airpurifier/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://github.com/xMrVizzy/philips-airpurifier",
   "dependencies": [],
   "codeowners": ["@xMrVizzy"],
-  "requirements": ["pycrypto"]
+  "requirements": ["pycryptodome"]
 }


### PR DESCRIPTION
This change let use this component with hassio in docker.

https://community.home-assistant.io/t/philips-air-purifier/53030/64